### PR TITLE
Add unit tests for common.GroupKey and utils.MD5

### DIFF
--- a/client/src/test/java/com/alibaba/nacos/client/config/common/GroupKeyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/common/GroupKeyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.client.config.common;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class GroupKeyTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testGetKey() {
+        Assert.assertEquals("1+foo", GroupKey.getKey("1", "foo"));
+        Assert.assertEquals("1+foo+bar", GroupKey.getKey("1", "foo", "bar"));
+        Assert.assertEquals("1+f%2Boo+b%25ar",
+            GroupKey.getKey("1", "f+oo", "b%ar"));
+    }
+
+    @Test
+    public void testGetKeyTenant() {
+        Assert.assertEquals("1+foo+bar",
+            GroupKey.getKeyTenant("1", "foo", "bar"));
+    }
+
+    @Test
+    public void testParseKey() {
+        Assert.assertArrayEquals(new String[]{null, "f+oo", null},
+            GroupKey.parseKey("f%2Boo"));
+        Assert.assertArrayEquals(new String[]{null, "f%oo", null},
+            GroupKey.parseKey("f%25oo"));
+    }
+
+    @Test
+    public void testParseKeyIllegalArgumentException1() {
+        thrown.expect(IllegalArgumentException.class);
+        GroupKey.parseKey("");
+    }
+
+    @Test
+    public void testParseKeyIllegalArgumentException2() {
+        thrown.expect(IllegalArgumentException.class);
+        GroupKey.parseKey("f%oo");
+    }
+
+    @Test
+    public void testParseKeyIllegalArgumentException3() {
+        thrown.expect(IllegalArgumentException.class);
+        GroupKey.parseKey("f+o+o+bar");
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/config/utils/MD5Test.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/utils/MD5Test.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.client.config.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MD5Test {
+
+    @Test
+    public void testGetMD5String() {
+        Assert.assertEquals("d41d8cd98f00b204e9800998ecf8427e",
+            MD5.getInstance().getMD5String(""));
+        Assert.assertEquals("acbd18db4cc2f85cedef654fccc4a4d8",
+            MD5.getInstance().getMD5String("foo"));
+
+        Assert.assertEquals("d41d8cd98f00b204e9800998ecf8427e",
+            MD5.getInstance().getMD5String(new byte[0]));
+        Assert.assertEquals("5289df737df57326fcdd22597afb1fac",
+            MD5.getInstance().getMD5String(new byte[]{1, 2, 3}));
+    }
+
+    @Test
+    public void testGetMD5Bytes() {
+        byte[] bytes1 = new byte[]{-44, 29, -116, -39, -113, 0, -78,
+            4, -23, -128, 9, -104, -20, -8, 66, 126};
+        byte[] bytes2 = new byte[]{82, -119, -33, 115, 125, -11, 115,
+            38, -4, -35, 34, 89, 122, -5, 31, -84};
+
+        Assert.assertArrayEquals(bytes1,
+            MD5.getInstance().getMD5Bytes(new byte[0]));
+        Assert.assertArrayEquals(bytes2,
+            MD5.getInstance().getMD5Bytes(new byte[]{1, 2, 3}));
+    }
+
+    @Test
+    public void testHash() {
+        byte[] bytes1 = new byte[]{-44, 29, -116, -39, -113, 0, -78,
+            4, -23, -128, 9, -104, -20, -8, 66, 126};
+        byte[] bytes2 = new byte[]{-84, -67, 24, -37, 76, -62, -8, 92,
+            -19, -17, 101, 79, -52, -60, -92, -40};
+        byte[] bytes3 = new byte[]{82, -119, -33, 115, 125, -11, 115,
+            38, -4, -35, 34, 89, 122, -5, 31, -84};
+
+        Assert.assertArrayEquals(bytes1, MD5.getInstance().hash(""));
+        Assert.assertArrayEquals(bytes2, MD5.getInstance().hash("foo"));
+        Assert.assertArrayEquals(bytes1, MD5.getInstance().hash(new byte[0]));
+        Assert.assertArrayEquals(bytes3,
+            MD5.getInstance().hash(new byte[]{1, 2, 3}));
+    }
+
+    @Test
+    public void testBytes2string() {
+        Assert.assertEquals("", MD5.getInstance().bytes2string(new byte[0]));
+        Assert.assertEquals("010203",
+            MD5.getInstance().bytes2string(new byte[]{1, 2, 3}));
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `com.alibaba.nacos.client.config.common.GroupKey` and `com.alibaba.nacos.client.config.utils.MD5` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.